### PR TITLE
Shell command fix

### DIFF
--- a/src/com/jenkins/aws/Pipeline.groovy
+++ b/src/com/jenkins/aws/Pipeline.groovy
@@ -192,7 +192,7 @@ def cloudFormationDescribeStacks(String stackName){
  *
  * @returns cli command status code if return status is 0, otherwise throws Exception with command output as body
  */
-def cloudFormationUpdateStack(String stackName, String templateFile, java.util.Map parameters, java.util.List<String> capabilities=[], boolean returnStatus = true){
+def cloudFormationUpdateStack(String stackName, String templateFile, java.util.Map parameters, java.util.List<String> capabilities=[], boolean returnStatus = false){
     def parametersString = ""
     parameters.each{ key, value ->
         parametersString += "ParameterKey=${key},ParameterValue='${value}' "

--- a/src/com/jenkins/aws/Pipeline.groovy
+++ b/src/com/jenkins/aws/Pipeline.groovy
@@ -27,7 +27,7 @@ def runShCommand(String script){
  *Assumes the command returns Json as output.
  */
 def executeShToObject(String command){
-    def (status, output) = runShCommand(script: command)
+    def (status, output) = runShCommand(command)
 
     if (status != 0){
         throw new Exception(output)
@@ -202,7 +202,7 @@ def cloudFormationUpdateStack(String stackName, String templateFile, java.util.M
         capabilitiesString += "${c} "
     }
     def command = "aws cloudformation update-stack --stack-name ${stackName} --capabilities ${capabilitiesString.trim()} --template-body file://${templateFile} --parameters ${parametersString.trim()}"
-    def (status, output) = runShCommand(script: command)
+    def (status, output) = runShCommand(command)
 
     println("cloudformation update-stack status code is: ${status}")
     println("cloudformation update-stack output is: ${output}")

--- a/src/com/jenkins/aws/Pipeline.groovy
+++ b/src/com/jenkins/aws/Pipeline.groovy
@@ -17,7 +17,7 @@ def runShCommand(String script){
     def file_name = "script_output_${random_num}.txt"
     def status = sh(returnStatus: true, script: "$script &> $file_name")
     def output = readFile(file_name).trim()
-    sh "rm $file_name"
+    sh "[ -e $file_name ] && rm $file_name"
 
     return [status, output]
 }

--- a/src/com/jenkins/aws/Pipeline.groovy
+++ b/src/com/jenkins/aws/Pipeline.groovy
@@ -14,7 +14,7 @@ def runShCommand(String script){
     Random rand = new Random()
     def random_num = rand.nextInt(100000)
 
-    def file_name = "script_output_$random_num.txt"
+    def file_name = "script_output_${random_num}.txt"
     def status = sh(returnStatus: true, script: "$script > $file_name")
     def output = readFile(file_name).trim()
     sh "rm $file_name"

--- a/src/com/jenkins/aws/Pipeline.groovy
+++ b/src/com/jenkins/aws/Pipeline.groovy
@@ -2,13 +2,19 @@ package com.aws
 import groovy.json.JsonSlurper
 
 /**
- Executes the given command and parse the output into object.
+ Executes the given command and parse the output into an object.
  *Assumes the command returns Json as output.
  */
 def executeShToObject(String command){
-    def output = sh(script: command, returnStdout:true).trim()
-    def jsonSlurper = new JsonSlurper()
-    return jsonSlurper.parseText(output)
+    def (status, output) = runShCommand(script: command)
+
+    if (status != 0){
+        throw new Exception(output)
+    }else {
+        def jsonSlurper = new JsonSlurper()
+        return jsonSlurper.parseText(output)
+    }
+
 }
 
 /**
@@ -107,7 +113,7 @@ def logsGetOrCreateLogGroup(String logGroupName){
  *                              "param2"     : "some-value",
  *                            ]
  * @param capabilities - list of capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM, CAPABILITY_AUTO_EXPAND
- * @returns if create stackId as String, in update returns the command status code
+ * @returns stack id as a String
  */
 def cloudFormationCreateStack(String stackName, String templateFile, java.util.Map parameters, java.util.List<String> capabilities=[]){
     def parametersString = ""
@@ -163,9 +169,7 @@ def cloudFormationDescribeStacks(String stackName){
  *                              "param2"     : "some-value",
  *                            ]
  *
- * @param returnStatus Normally, a script which exits with a nonzero status code will cause the step to fail with an exception.
- *         If this option is checked, the return value of the step will instead be the status code. You may then compare it to zero, for example
- * @returns cli command status code
+ * @returns cli command status code if return status is 0, otherwise throws Exception with command output as body
  */
 def cloudFormationUpdateStack(String stackName, String templateFile, java.util.Map parameters, java.util.List<String> capabilities=[], boolean returnStatus = true){
     def parametersString = ""
@@ -177,15 +181,35 @@ def cloudFormationUpdateStack(String stackName, String templateFile, java.util.M
         capabilitiesString += "${c} "
     }
     def command = "aws cloudformation update-stack --stack-name ${stackName} --capabilities ${capabilitiesString.trim()} --template-body file://${templateFile} --parameters ${parametersString.trim()}"
-    def output = sh(script: command, returnStatus:returnStatus)
+    def (status, output) = runShCommand(script: command)
 
-    if (returnStatus){
-        println("cloudformation update-stack status code is: ${output}")
-    }else{
-        println("cloudformation update-stack output is: ${output}")
+    println("cloudformation update-stack status code is: ${status}")
+    println("cloudformation update-stack output is: ${output}")
+
+    if(status != 0 && !returnStatus){
+        throw new Exception(output)
     }
+    return status
+}
 
-    return output
+/**
+ * Runs an sh command and returns both the status and output as a tuple.
+ * Example:
+ * (status, output) = runShCommand('ls -ltr')
+ * @param script - the script to execute
+ * @return a tuple of (status, output)
+ */
+def runShCommand(String script){
+
+    Random rand = new Random()
+    def random_num = rand.nextInt(100000)
+
+    def file_name = "script_output_$random_num.txt"
+    def status = sh(returnStatus: true, script: "$script > $file_name")
+    def output = readFile(file_name).trim()
+    sh "rm $file_name"
+
+    return [status, output]
 }
 
 /**
@@ -293,11 +317,9 @@ def cloudFormationWaitStackDeleteComplete(String stackName){
  *                              "param2"     : "some-value",
  *                            ]
  *
- * @param returnStatus Normally, a script which exits with a nonzero status code will cause the step to fail with an exception.
- *          If this option is checked, the return value of the step will instead be the status code. You may then compare it to zero, for example
  * @returns cli command status code
  */
-def cloudFormationCreateOrUpdateStack(String stackName, String templateFile, java.util.Map parameters, java.util.List<String> capabilities = [], boolean returnStatus = true){
+def cloudFormationCreateOrUpdateStack(String stackName, String templateFile, java.util.Map parameters, java.util.List<String> capabilities = []){
     def parametersString = ""
     parameters.each{ key, value ->
         parametersString += "ParameterKey=${key},ParameterValue='${value}' "
@@ -309,9 +331,9 @@ def cloudFormationCreateOrUpdateStack(String stackName, String templateFile, jav
 
     if (cloudFormationStackExist(stackName)){
         println("cloudformation stack ${stackName} exist, executing update-stack command")
-        return cloudFormationUpdateStack(stackName, templateFile, parameters, capabilities, returnStatus)
+        return cloudFormationUpdateStack(stackName, templateFile, parameters, capabilities)
     }
-    return  cloudFormationCreateStack(stackName, templateFile, parameters, capabilities)
+    return cloudFormationCreateStack(stackName, templateFile, parameters, capabilities)
 
 }
 

--- a/src/com/jenkins/aws/Pipeline.groovy
+++ b/src/com/jenkins/aws/Pipeline.groovy
@@ -1,6 +1,27 @@
 package com.aws
 import groovy.json.JsonSlurper
 
+
+/**
+ * Runs an sh command and returns both the status and output as a tuple.
+ * Example:
+ * (status, output) = runShCommand('ls -ltr')
+ * @param script - the script to execute
+ * @return a tuple of (status, output)
+ */
+def runShCommand(String script){
+
+    Random rand = new Random()
+    def random_num = rand.nextInt(100000)
+
+    def file_name = "script_output_$random_num.txt"
+    def status = sh(returnStatus: true, script: "$script > $file_name")
+    def output = readFile(file_name).trim()
+    sh "rm $file_name"
+
+    return [status, output]
+}
+
 /**
  Executes the given command and parse the output into an object.
  *Assumes the command returns Json as output.
@@ -192,25 +213,7 @@ def cloudFormationUpdateStack(String stackName, String templateFile, java.util.M
     return status
 }
 
-/**
- * Runs an sh command and returns both the status and output as a tuple.
- * Example:
- * (status, output) = runShCommand('ls -ltr')
- * @param script - the script to execute
- * @return a tuple of (status, output)
- */
-def runShCommand(String script){
 
-    Random rand = new Random()
-    def random_num = rand.nextInt(100000)
-
-    def file_name = "script_output_$random_num.txt"
-    def status = sh(returnStatus: true, script: "$script > $file_name")
-    def output = readFile(file_name).trim()
-    sh "rm $file_name"
-
-    return [status, output]
-}
 
 /**
  * Executes AWS CloudFormation wait stack-create-completed

--- a/src/com/jenkins/aws/Pipeline.groovy
+++ b/src/com/jenkins/aws/Pipeline.groovy
@@ -15,7 +15,7 @@ def runShCommand(String script){
     def random_num = rand.nextInt(100000)
 
     def file_name = "script_output_${random_num}.txt"
-    def status = sh(returnStatus: true, script: "$script > $file_name")
+    def status = sh(returnStatus: true, script: "$script &> $file_name")
     def output = readFile(file_name).trim()
     sh "rm $file_name"
 


### PR DESCRIPTION
when using the build in `sh()` command in jenkins you'll get an exception if the returned status code is not 0. Using `returnStatus=true` one can change this and get the status code rather than throwing an exception, however if you use `returnStatus` you'll not be able to get the command text.
This pull fixes that